### PR TITLE
feat: remove useless route path and fix robot style issue

### DIFF
--- a/.vitepress/config.mts
+++ b/.vitepress/config.mts
@@ -1,11 +1,26 @@
 import vueJsx from '@vitejs/plugin-vue-jsx'
-import { fileURLToPath } from 'url'
 import { defineConfig } from 'vitepress'
 import { vitepressDemoPlugin } from 'vitepress-demo-plugin'
+import path from 'path'
+import { fileURLToPath } from 'url'
 
-const prodAlias = {
-  '@opentiny/tiny-robot-style': '@opentiny/tiny-robot/dist/style.css',
-}
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const rootDir = path.resolve(__dirname, '..')
+
+const resolveSubmoduleRelativePathsPlugin = (options: { source: string; target: string }[] = []) => ({
+  name: 'resolve-submodule-relative-paths',
+  // source: 导入的路径，例如 '../../demos/attachments/basic.vue'
+  // importer: 发起导入的文件路径，例如 '.../docs/project-a/docs/src/components/bubble.md'
+  resolveId(source, importer) {
+
+    const index = options.findIndex(option => source.includes(option.source))
+    if (index !== -1) {
+      return source.replace(options[index].source, options[index].target || '')
+    }
+    // 如果不满足条件，则不处理
+    return null
+  },
+})
 
 // https://vitepress.dev/reference/site-config
 export default defineConfig({
@@ -15,11 +30,14 @@ export default defineConfig({
   base: process.env.VITEPRESS_BASE || '/',
   head: [['link', { rel: 'icon', href: '/logo-mini.svg' }]],
   vite: {
-    plugins: [vueJsx()],
+    plugins: [vueJsx(), resolveSubmoduleRelativePathsPlugin([{
+      source: path.resolve(rootDir, 'demos'),
+      target: path.resolve(rootDir, 'tiny-robot/docs/demos'),
+    }])],
     server: { open: true },
     resolve: {
       alias: {
-        ...prodAlias,
+        '@opentiny/tiny-robot-style': '../../tiny-robot/packages/components/dist/style.css',
       },
     },
   },
@@ -28,21 +46,25 @@ export default defineConfig({
       md.use(vitepressDemoPlugin)
     },
   },
+  rewrites: {
+    'tiny-robot/docs/src/:path*': 'tiny-robot/:path*',
+    'next-sdk/docs/:path*': 'next-sdk/:path*',
+  },
   themeConfig: {
     // https://vitepress.dev/reference/default-theme-config
     logo: '/logo-mini.svg',
     siteTitle: 'OpenTiny NEXT',
     nav: [
-      { text: '指南', link: '/tiny-robot/docs/src/guide/installation', activeMatch: '/guide/' },
-      { text: '组件', link: '/tiny-robot/docs/src/components/bubble', activeMatch: '/components/' },
-      { text: '工具', link: '/tiny-robot/docs/src/tools/ai-client', activeMatch: '/tools/' },
-      { text: '演示', link: '/tiny-robot/docs/src/examples/assistant', activeMatch: '/examples/' },
+      { text: '指南', link: '/tiny-robot/guide/installation', activeMatch: '/guide/' },
+      { text: '组件', link: '/tiny-robot/components/bubble', activeMatch: '/components/' },
+      { text: '工具', link: '/tiny-robot/tools/ai-client', activeMatch: '/tools/' },
+      { text: '演示', link: '/tiny-robot/examples/assistant', activeMatch: '/examples/' },
     ],
     sidebar: {
-      '/tiny-robot/docs/src/components/': [
+      '/tiny-robot/components/': [
         {
           text: '组件',
-          base: '/tiny-robot/docs/src/components/',
+          base: '/tiny-robot/components/',
           items: [
             { text: 'Container 容器', link: 'container' },
             { text: 'Bubble 气泡', link: 'bubble' },
@@ -61,10 +83,10 @@ export default defineConfig({
           ],
         },
       ],
-      '/tiny-robot/docs/src/tools/': [
+      '/tiny-robot/tools/': [
         {
           text: '工具',
-          base: '/tiny-robot/docs/src/tools/',
+          base: '/tiny-robot/tools/',
           items: [
             { text: 'AI模型交互工具类', link: 'ai-client' },
             { text: '消息数据管理', link: 'message' },

--- a/.vitepress/theme/index.ts
+++ b/.vitepress/theme/index.ts
@@ -1,6 +1,7 @@
 import DefaultTheme from 'vitepress/theme'
 import { setupDarkModeListener } from './color-mode'
 import Layout from './Layout.vue'
+import '@opentiny/tiny-robot-style'
 import './style.css'
 
 declare global {


### PR DESCRIPTION
1. 修复TinyRobot样式未生效问题

2. 移除submodule导致的URL多余路径
- `https://{domain}/tiny-robot/docs/src/xxx`  -->  `https://{domain}/tiny-robot/xxx`
- `https://{domain}/next-sdk/docs/xxx`  -->  `https://{domain}/next-sdk/xxx`

<img width="1140" height="801" alt="image" src="https://github.com/user-attachments/assets/21da4ad6-4686-4a52-bc80-e91026575590" />
