### PR TITLE
feat: add submodule: [web-agent] and intergate docs into doc site

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -17,3 +17,6 @@
 [submodule "tiny-editor"]
 	path = tiny-editor
 	url = git@github.com:opentiny/tiny-editor.git
+[submodule "web-agent"]
+	path = web-agent
+	url = git@github.com:opentiny/web-agent.git

--- a/.vitepress/config.mts
+++ b/.vitepress/config.mts
@@ -7,6 +7,17 @@ import { fileURLToPath } from 'url'
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 const rootDir = path.resolve(__dirname, '..')
+const WebAgentSidebar = [
+  {
+    text: '使用文档',
+    base: '/web-agent/guide/',
+    items: [
+      { text: '快速开始', link: 'getting-started' },
+      { text: '架构设计', link: 'architecture' },
+      { text: 'API 参考', link: 'api-reference' }
+    ]
+  }
+]
 const TinyEditorSidebar = [
     {
       text: '基础',
@@ -216,6 +227,7 @@ export default defineConfig({
     'tiny-editor/packages/docs/fluent-editor/docs/demo/:path*': 'tiny-editor/demo/:path*',
     'tiny-editor/packages/docs/fluent-editor/docs/api/:path*': 'tiny-editor/api/:path*',
     'tiny-editor/packages/docs/fluent-editor/docs/modules/:path*': 'tiny-editor/modules/:path*',
+    'web-agent/docs/:path*': 'web-agent/guide/:path*'
   },
   themeConfig: {
     // https://vitepress.dev/reference/default-theme-config
@@ -682,6 +694,7 @@ export default defineConfig({
       '/tiny-editor/demo/': TinyEditorSidebar,
       '/tiny-editor/api/': TinyEditorSidebar,
       '/tiny-editor/modules/': TinyEditorSidebar,
+      '/web-agent/guide/': WebAgentSidebar,
     },
     search: {
       provider: 'local'

--- a/.vitepress/theme/Layout.vue
+++ b/.vitepress/theme/Layout.vue
@@ -97,6 +97,10 @@ const redirectMap = [
   { 
     patterns: ['/genui-sdk.html', '/genui-sdk/', '/genui-sdk/guide.html', '/genui-sdk/guide/'],
     target: '/genui-sdk/guide/quick-start'
+  },
+  {
+    patterns: ['/web-agent.html', '/web-agent/', '/web-agent/guide.html', '/web-agent/guide/'],
+    target: '/web-agent/guide/getting-started'
   }
 ];
 
@@ -148,13 +152,15 @@ const updateDocTitle = () => {
     }
   }
 
-  // next-sdk / tiny-vue: 从对应 sidebar 的 guide 中寻找匹配项
-  if (path.includes('/next-sdk/') || path.includes('/tiny-vue/')) {
+  // next-sdk / tiny-vue / web-agent: 从对应 sidebar 的 guide 中寻找匹配项
+  if (path.includes('/next-sdk/') || path.includes('/tiny-vue/') || path.includes('/web-agent/')) {
     let sidebarConfig: any[] = []
     if (path.includes('/next-sdk/')) {
       sidebarConfig = cfg.sidebar?.['/next-sdk/guide/'] || []
     } else if (path.includes('/tiny-vue/')) {
       sidebarConfig = cfg.sidebar?.['/tiny-vue/guide/'] || []
+    } else if (path.includes('/web-agent/')) {
+      sidebarConfig = cfg.sidebar?.['/web-agent/guide/'] || []
     }
 
     if (!sidebarConfig || !sidebarConfig.length) {

--- a/.vitepress/theme/components/CustomHeader.vue
+++ b/.vitepress/theme/components/CustomHeader.vue
@@ -23,7 +23,7 @@
               :tabs="productTabs"
               :activeTab="activeProductTab"
               @tab-change="handleProductTabChange"
-              style="width: 810px"
+              style="width: 980px"
             />
           </div>
         </div>
@@ -327,6 +327,7 @@ const getActiveNavTab = () => {
     "next-sdk": ["/next-sdk/"],
     "tiny-robot": ["/components/", "/tools/"],
     "tiny-editor": ["/demo/", "/api/", "/modules/"],
+    "web-agent": ["/web-agent/"],
   };
 
   const segments = productPathMap[activeProductTab.value] || [];
@@ -459,6 +460,14 @@ const productTabs = computed(() => [
       activeProductTab.value === "tiny-editor" ? "active" : "normal"
     }-tiny-editor.svg`,
   },
+  {
+    key: "web-agent",
+    name: "WebAgent",
+    link: `${prefix}web-agent/guide/getting-started`,
+    src: `${prefix}images/logo-${
+      activeProductTab.value === "web-agent" ? "active" : "normal"
+    }-web-agent.svg`,
+  },
 ]);
 
 // 切换tab时路由跳转
@@ -488,6 +497,8 @@ watch(
       activeProductTab.value = "tiny-engine";
     } else if (path.includes("/tiny-editor/")) {
       activeProductTab.value = "tiny-editor";
+    } else if (path.includes("/web-agent/")) {
+      activeProductTab.value = "web-agent";
     } else {
       activeProductTab.value = "";
     }

--- a/.vitepress/theme/entity/nav-tab.ts
+++ b/.vitepress/theme/entity/nav-tab.ts
@@ -85,12 +85,23 @@ class TinyEditorNavTab extends NavTab {
   }
 }
 
+class WebAgentNavTab extends NavTab {
+  constructor(activeProductTab: string, site: any, themeConfig?: any) {
+    super(activeProductTab, site, themeConfig)
+  }
+
+  getTabs(): TabItem[] {
+    return [{ key: 'guide', name: '使用文档', link: '/web-agent/guide/getting-started' }]
+  }
+}
+
 const navTabClassMap: Record<string, NavTabConstructor> = {
   'next-sdk': NextSdkNavTab,
   'tiny-vue': TinyVueNavTab,
   'tiny-engine': TinyEngineNavTab,
   'genui-sdk': GenuiSdkNavTab,
-  'tiny-editor': TinyEditorNavTab
+  'tiny-editor': TinyEditorNavTab,
+  'web-agent': WebAgentNavTab
 }
 
 const navPathMap: Record<string, string> = {
@@ -98,7 +109,8 @@ const navPathMap: Record<string, string> = {
   'tiny-vue': '/tiny-vue/',
   'tiny-engine': '/tiny-engine/',
   'genui-sdk': '/genui-sdk/',
-  'tiny-editor': '/tiny-editor/'
+  'tiny-editor': '/tiny-editor/',
+  'web-agent': '/web-agent/'
 }
 
 const NavTabFactory = (activeProductTab: string, route: any, site: any, themeConfig: any) => {
@@ -113,6 +125,5 @@ const NavTabFactory = (activeProductTab: string, route: any, site: any, themeCon
 
   return new NavTab(activeProductTab, site, themeConfig)
 }
-
 
 export { NavTabFactory }

--- a/public/images/logo-active-web-agent.svg
+++ b/public/images/logo-active-web-agent.svg
@@ -1,0 +1,4 @@
+<svg width="40" height="40" viewBox="0 0 40 40" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="40" height="40" rx="8" fill="#1476FF"/>
+  <path d="M8.5 11.5L12.8 28.5H16.7L20 18.6L23.3 28.5H27.2L31.5 11.5H27.5L25 22.3L21.7 11.5H18.3L15 22.3L12.5 11.5H8.5Z" fill="white"/>
+</svg>

--- a/public/images/logo-normal-web-agent.svg
+++ b/public/images/logo-normal-web-agent.svg
@@ -1,0 +1,4 @@
+<svg width="40" height="40" viewBox="0 0 40 40" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="40" height="40" rx="8" fill="#7EB7FC"/>
+  <path d="M8.5 11.5L12.8 28.5H16.7L20 18.6L23.3 28.5H27.2L31.5 11.5H27.5L25 22.3L21.7 11.5H18.3L15 22.3L12.5 11.5H8.5Z" fill="white"/>
+</svg>


### PR DESCRIPTION
【描述】
1. 增加 web-agent 子模块。
2. 集成web-agent 子模块文档到 opentiny 文档。


<img width="1587" height="1186" alt="image" src="https://github.com/user-attachments/assets/a43766ec-14b6-4ce0-bcd5-5dd196ca5b18" />

<img width="474" height="782" alt="image" src="https://github.com/user-attachments/assets/46b66348-c55e-437a-8087-85fe86345312" />

<img width="1001" height="793" alt="image" src="https://github.com/user-attachments/assets/8c989b06-9e95-49b2-9a1e-62b94b8b1b23" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added web-agent as a new product in site navigation
  * Introduced web-agent documentation section with getting started guide, architecture design, and API reference resources
  * Web-agent now accessible via dedicated navigation tab alongside other products

<!-- end of auto-generated comment: release notes by coderabbit.ai -->