### PR TITLE
feat: except for the TinyRobot page, other pages have hidden playground buttons

### DIFF
--- a/.vitepress/theme/index.ts
+++ b/.vitepress/theme/index.ts
@@ -9,7 +9,7 @@ import MermaidBlock from './components/MermaidBlock.vue'
 import '@opentiny/tiny-robot-style'
 import {nextTick, watch} from 'vue';
 import {useRoute} from 'vitepress';
-import mediumZoom from 'medium-zoom';
+import mediumZoom, { Zoom } from 'medium-zoom';
 import { insertFurion } from './insert-furion'
 // 引入样式文件
 import './medium-zoom.css';
@@ -45,15 +45,15 @@ export default {
   setup() {
     // 为img元素添加点击放大功能并根据路由隐藏 playground 图标
     const route = useRoute();
-    let zomm: any = null;
+    let zoom: Zoom | null = null;
     watch(
       () => route.path,
       () => nextTick(() => {
-        if (zomm) {
-          zomm.detach();
+        if (zoom) {
+          zoom.detach();
         }
         if (typeof window !== 'undefined'){
-          zomm = mediumZoom('.main img', {background: 'var(--vp-c-bg)'})
+          zoom = mediumZoom('.main img', {background: 'var(--vp-c-bg)'})
           if (route.path.includes('tiny-robot')) {
             document.body.classList.remove('hide-code-playground');
           } else {

--- a/.vitepress/theme/index.ts
+++ b/.vitepress/theme/index.ts
@@ -43,7 +43,7 @@ export default {
   },
   Layout,
   setup() {
-    // 为img元素添加点击放大功能
+    // 为img元素添加点击放大功能并根据路由隐藏 playground 图标
     const route = useRoute();
     let zomm: any = null;
     watch(
@@ -54,6 +54,11 @@ export default {
         }
         if (typeof window !== 'undefined'){
           zomm = mediumZoom('.main img', {background: 'var(--vp-c-bg)'})
+          if (route.path.includes('tiny-robot')) {
+            document.body.classList.remove('hide-code-playground');
+          } else {
+            document.body.classList.add('hide-code-playground');
+          }
         }
       }),
       {immediate: true}

--- a/.vitepress/theme/style.css
+++ b/.vitepress/theme/style.css
@@ -177,6 +177,11 @@ body,
 .VPContent {
   padding-top: 0 !important;
 }
+
+/* 隐藏代码 playground 图标，在除了 tiny-robot 路由下启用 */
+body.hide-code-playground .lucide.lucide-play-icon.lucide-play {
+  display: none !important;
+}
 .VPHome .container {
   max-width: 92rem;
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Code playground play icon visibility is now controlled by page: hidden by default and shown only on the designated route (tiny-robot).

* **Bug Fixes**
  * Improved behavior when navigating pages to ensure image zoom instances are cleaned up and re-initialized correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->