### PR TITLE
fix(ci): remove workflow-level env block exposing secrets

### DIFF
--- a/.github/workflows/deploy-obs.yml
+++ b/.github/workflows/deploy-obs.yml
@@ -17,13 +17,6 @@ on:
         required: false
         type: string
 
-env:
-  # 在 GitHub 项目源码仓库 → 项目的 Settings → Secrets(Actions 里的 Repository secrets) 里提前建好以下变量
-  HUAWEI_CLOUD_AK: ${{ secrets.HUAWEI_CLOUD_AK }}
-  HUAWEI_CLOUD_SK: ${{ secrets.HUAWEI_CLOUD_SK }}
-  HUAWEI_CLOUD_ENDPOINT: ${{ secrets.HUAWEI_CLOUD_ENDPOINT }}
-  HUAWEI_CLOUD_BUCKET: ${{ secrets.HUAWEI_CLOUD_BUCKET }}
-
 permissions:
   contents: read
   pages: write
@@ -111,11 +104,11 @@ jobs:
       - name: Upload to OBS
         run: |
           # 一次性配置 AK/SK/endpoint
-          obsutil config -i=${{ env.HUAWEI_CLOUD_AK }} \
-                         -k=${{ env.HUAWEI_CLOUD_SK }} \
-                         -e=${{ env.HUAWEI_CLOUD_ENDPOINT }}
+          obsutil config -i=${{ secrets.HUAWEI_CLOUD_AK }} \
+                         -k=${{ secrets.HUAWEI_CLOUD_SK }} \
+                         -e=${{ secrets.HUAWEI_CLOUD_ENDPOINT }}
 
           # 把本地 dist/ 目录整站同步到桶根目录
           echo "needs.build.outputs.version: ${{ needs.build.outputs.version }}"
           mv dist ${{ needs.build.outputs.version }}
-          obsutil cp ${{ needs.build.outputs.version }} obs://${{ env.HUAWEI_CLOUD_BUCKET }}/opentiny-docs/ -r -f
+          obsutil cp ${{ needs.build.outputs.version }} obs://${{ secrets.HUAWEI_CLOUD_BUCKET }}/opentiny-docs/ -r -f


### PR DESCRIPTION
## Summary

- 移除 `deploy-obs.yml` 中顶层 `env:` 块对 `HUAWEI_CLOUD_*` secrets 的环境变量映射
- 将所有 `${{ env.HUAWEI_CLOUD_* }}` 引用替换为 `${{ secrets.HUAWEI_CLOUD_* }}` 直接引用

**安全问题：** 顶层 `env:` 会将 secrets 暴露为整个 workflow 的环境变量，任何 step 都可通过 `printenv` 读取。改为直接引用 `${{ secrets.* }}` 后，secrets 仅在使用处临时展开。

参照: opentiny/tiny-engine#1799

## Test plan

- [ ] 确认 workflow 文件 YAML 语法正确
- [ ] 下次发布 tag 触发 deploy-obs workflow 时验证 OBS 上传功能正常

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated continuous integration deployment configuration to streamline credential handling within the build pipeline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->