### PR TITLE
feat: solve the problem of TinyEditor document demo not displaying

### DIFF
--- a/.vitepress/config.mts
+++ b/.vitepress/config.mts
@@ -3,6 +3,7 @@ import { defineConfig } from 'vitepress'
 import { vitepressDemoPlugin } from 'vitepress-demo-plugin'
 import { tabsMarkdownPlugin } from 'vitepress-plugin-tabs'
 import { isMermaidFence, renderMermaidFence } from './theme/markdown/mermaid'
+import { tinyEditorDemoPlugin } from './theme/markdown/tiny-editor-demo'
 import path from 'path'
 import { fileURLToPath } from 'url'
 
@@ -187,6 +188,8 @@ export default defineConfig({
   },
   markdown: {
     config: (md) => {
+      // tiny-editor 的 :::demo src=... 转成 <demo vue="..." />，再交给 vitepress-demo-plugin
+      md.use(tinyEditorDemoPlugin)
       md.use(vitepressDemoPlugin, {
         playground: { show: true },
         codeTransformer: (code) => {

--- a/.vitepress/theme/index.ts
+++ b/.vitepress/theme/index.ts
@@ -7,6 +7,7 @@ import HomePage from './home/index.vue'
 import CustomTable from './components/CustomTable.vue'
 import MermaidBlock from './components/MermaidBlock.vue'
 import '@opentiny/tiny-robot-style'
+import '@opentiny/fluent-editor/style.css'
 import {nextTick, watch} from 'vue';
 import {useRoute} from 'vitepress';
 import mediumZoom, { Zoom } from 'medium-zoom';

--- a/.vitepress/theme/markdown/tiny-editor-demo.ts
+++ b/.vitepress/theme/markdown/tiny-editor-demo.ts
@@ -1,0 +1,23 @@
+/**
+ * 将 tiny-editor 文档中的 :::demo src=... 语法
+ * 转换为主站 vitepress-demo-plugin 可解析的 <demo vue="..." />。
+ *
+ * tiny-editor 独立站点使用 @vitepress-code-preview，
+ * 统一文档站使用 vitepress-demo-plugin，语法不兼容。
+ */
+export function transformTinyEditorDemoMarkdown(src: string) {
+  // docs/demo/*.md 中 src=demos/xxx.vue，相对路径为 ../../demos/xxx.vue
+  return src.replace(/:::demo\s+src=([^\s]+)\s*\r?\n:::/g, (_match, demoSrc: string) => {
+    const vuePath = demoSrc.startsWith('demos/') ? `../../${demoSrc}` : demoSrc
+    return `<demo vue="${vuePath}" />`
+  })
+}
+
+export function tinyEditorDemoPlugin(md: {
+  parse: (src: string, env: Record<string, unknown>) => unknown
+}) {
+  const parse = md.parse.bind(md)
+  md.parse = (src: string, env: Record<string, unknown>) => {
+    return parse(transformTinyEditorDemoMarkdown(src), env)
+  }
+}

--- a/.vitepress/theme/style.css
+++ b/.vitepress/theme/style.css
@@ -24,6 +24,18 @@ body,
   scrollbar-width: thin;
 }
 
+/* ===== TinyEditor Demo：避免 VitePress 文档样式覆盖编辑器 ===== */
+.vp-doc[class*="_tiny-editor_"] .vitepress-demo-plugin-preview .ql-editor ul,
+.vp-doc[class*="_tiny-editor_"] .vitepress-demo-plugin-preview .ql-editor ol {
+  list-style: revert;
+  padding: revert;
+  margin: revert;
+}
+
+.vp-doc[class*="_tiny-editor_"] .vitepress-demo-plugin-preview .ql-editor li + li {
+  margin: revert;
+}
+
 /* ===== VitePress Demo 插件样式 ===== */
 .vitepress-demo-plugin__container {
   background-color: #fafafa;


### PR DESCRIPTION
文档系统中TinyEditor下面的:::demo src=... 无法解析，是因为主站用的是 vitepress-demo-plugin（只认 <demo vue="..." />），而 tiny-editor 原文是 @vitepress-code-preview 的 :::demo 语法，导致demo无法显示
修改前
<img width="750" height="429" alt="old" src="https://github.com/user-attachments/assets/a1c14e4c-947b-4c9a-921e-261ff815341a" />
修改后
<img width="795" height="547" alt="new" src="https://github.com/user-attachments/assets/9a907893-9539-45b9-a5fa-9a6ad3b91eda" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for rendering TinyEditor demos directly in documentation pages.
  * Included Fluent Editor styling in the documentation theme.

* **Bug Fixes**
  * Improved TinyEditor demo presentation by preventing documentation styles from affecting editor previews, including list formatting and spacing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->