### PR TITLE
chore: update genui-sdk to 1.3.0 

### DIFF
--- a/.vitepress/config.mts
+++ b/.vitepress/config.mts
@@ -445,7 +445,7 @@ export default defineConfig({
       ],
       '/genui-sdk/examples/': [
         {
-          text: 'Vue组件特性示例',
+          text: 'Vue组件 特性示例',
           collapsed: false,
           items: [
             {

--- a/.vitepress/config.mts
+++ b/.vitepress/config.mts
@@ -388,8 +388,7 @@ export default defineConfig({
           base: '/genui-sdk/guide/',
           items: [
             { text: '快速开始', link: 'quick-start' },
-            { text: '使用 Renderer 组件', link: 'start-with-renderer' },
-            { text: '搭配 TinyRobot 使用', link: 'renderer-with-tiny-robot' }
+            { text: '使用 Renderer 组件', link: 'start-with-renderer' }
           ]
         },
         {
@@ -408,7 +407,7 @@ export default defineConfig({
       ],
       '/genui-sdk/components/': [
         {
-          text: 'Vue组件文档',
+          text: 'Vue 组件文档',
           base: '/genui-sdk/components/',
           items: [
             { text: 'GenuiRenderer', link: 'renderer' },
@@ -417,7 +416,7 @@ export default defineConfig({
           ]
         },
         {
-          text: 'Angular组件文档',
+          text: 'Angular 组件文档',
           base: '/genui-sdk/components/',
           items: [{ text: 'GenuiRenderer', link: 'angular/renderer' }]
         },
@@ -428,11 +427,25 @@ export default defineConfig({
             { text: 'API 参考', link: 'server/api' },
             { text: 'CLI', link: 'server/cli' }
           ]
+        },
+        {
+          text: 'Core 库文档',
+          base: '/genui-sdk/components/',
+          items: [{ text: 'API 文档', link: 'core/api' }]
+        },
+        {
+          text: '物料包文档',
+          base: '/genui-sdk/components/',
+          items: [
+            { text: 'Vue OpenTiny Vue', link: 'materials/vue-opentiny-vue' },
+            { text: 'Vue Element Plus', link: 'materials/vue-element-plus' },
+            { text: 'Angular OpenTiny NG', link: 'materials/angular-opentiny-ng' }
+          ]
         }
       ],
       '/genui-sdk/examples/': [
         {
-          text: 'Vue 组件特性示例',
+          text: 'Vue组件特性示例',
           collapsed: false,
           items: [
             {

--- a/genui/package.json
+++ b/genui/package.json
@@ -12,7 +12,7 @@
   "license": "MIT",
   "dependencies": {
     "@opentiny/genui-sdk-angular": "workspace:*",
-    "@opentiny/genui-sdk-vue": "1.1.1"
+    "@opentiny/genui-sdk-vue": "1.3.0"
   },
   "devDependencies": {
     "vitepress": "^1.6.3",

--- a/genui/package.json
+++ b/genui/package.json
@@ -12,6 +12,7 @@
   "license": "MIT",
   "dependencies": {
     "@opentiny/genui-sdk-angular": "workspace:*",
+    "@opentiny/genui-sdk-materials-vue-opentiny-vue": "1.3.0",
     "@opentiny/genui-sdk-vue": "1.3.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "0.1.0",
   "scripts": {
     "dev": "cross-env VP_MODE=development vitepress dev",
-    "prebuild": "pnpm -F @opentiny/genui-sdk-core build && pnpm -F @opentiny/genui-sdk-angular build:element && pnpm build:playground",
+    "prebuild": "pnpm -F @opentiny/genui-sdk-core build && pnpm -F @opentiny/genui-sdk-materials-angular-opentiny-ng build && pnpm -F @opentiny/tiny-schema-renderer-ng build && pnpm -F @opentiny/genui-sdk-angular build:element",
     "build": "cross-env VP_MODE=production NODE_OPTIONS=\"--max-old-space-size=8192\" vitepress build",
     "build:playground": "node scripts/build-playground.js",
     "postbuild": "node scripts/copy-playground.js tiny-robot/packages/playground/dist dist/tiny-robot/playground",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "version": "0.1.0",
   "scripts": {
     "dev": "cross-env VP_MODE=development vitepress dev",
-    "prebuild": "pnpm -F @opentiny/genui-sdk-core build && pnpm -F @opentiny/genui-sdk-materials-angular-opentiny-ng build && pnpm -F @opentiny/tiny-schema-renderer-ng build && pnpm -F @opentiny/genui-sdk-angular build:element",
+    "prebuild:genui": "pnpm -F @opentiny/genui-sdk-core build && pnpm -F @opentiny/genui-sdk-materials-angular-opentiny-ng build && pnpm -F @opentiny/tiny-schema-renderer-ng build && pnpm -F @opentiny/genui-sdk-angular build:element",
+    "prebuild": "pnpm prebuild:genui && pnpm build:playground",
     "build": "cross-env VP_MODE=production NODE_OPTIONS=\"--max-old-space-size=8192\" vitepress build",
     "build:playground": "node scripts/build-playground.js",
     "postbuild": "node scripts/copy-playground.js tiny-robot/packages/playground/dist dist/tiny-robot/playground",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,4 +3,5 @@ packages:
   - genui
   - genui/genui-sdk/packages/frameworks/angular
   - genui/genui-sdk/packages/core
+  - genui/genui-sdk/packages/materials/angular-opentiny-ng
   - genui/genui-sdk/projects/tiny-schema-renderer-ng


### PR DESCRIPTION
## Summary
- 将 `genui/genui-sdk` submodule 更新至最新commit
- 将 `@opentiny/genui-sdk-vue` 依赖更新为 `1.3.0`
- 同步 GenUI SDK 文档侧栏（新增 Core 库文档、物料包文档）

## Test plan
- [ ] docs 站点 genui-sdk 文档可正常打开
- [ ] 侧栏链接无 404
- [ ] 依赖版本与 npm 已发布版本一致


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Refreshed the GenUI SDK documentation navigation with clearer Vue and Angular section titles.
  * Added dedicated documentation sections for the Core library and material packages.
  * Updated the examples label and streamlined guide links.

* **New Features**
  * Added support for the latest GenUI SDK Vue release.
  * Introduced Vue material components and expanded Angular material package coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->